### PR TITLE
chore: change output format to es6 "module"

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -11,6 +11,6 @@ export default defineConfig({
   input: "src/index.ts",
   output: {
     file: "dist/index.js",
-    format: "cjs",
+    format: "module",
   },
 });


### PR DESCRIPTION
It should be "module" same as it declared in package.json "type" property. After this fix I can use this package without error 

SyntaxError: The requested module 'google-sheet-languages-model' does not provide an export named 'GoogleSheetLanguagesModel'